### PR TITLE
Move __future__ import to top of file

### DIFF
--- a/07-the-sound-of-hydrogen.ipynb
+++ b/07-the-sound-of-hydrogen.ipynb
@@ -48,14 +48,14 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import division, print_function, absolute_import\n",
     "import scipy.constants as const\n",
     "import numpy as np\n",
     "import scipy\n",
     "\n",
     "from matplotlib.pyplot import plot\n",
     "from scipy.io import wavfile\n",
-    "from IPython.core.display import HTML, display\n",
-    "from __future__ import division"
+    "from IPython.core.display import HTML, display"
    ]
   },
   {
@@ -193,8 +193,6 @@
    },
    "outputs": [],
    "source": [
-    "from __future__ import division, print_function, absolute_import\n",
-    "\n",
     "import numpy\n",
     "import struct\n",
     "import warnings    "


### PR DESCRIPTION
Moving the __future__ import to the top of the file as executing the current notebook in Jupyter results in a `SyntaxError: from __future__ imports must occur at the beginning of the file`.